### PR TITLE
SLING-7299 do not always attach built artifact

### DIFF
--- a/src/main/java/org/apache/sling/maven/slingstart/AbstractSlingStartMojo.java
+++ b/src/main/java/org/apache/sling/maven/slingstart/AbstractSlingStartMojo.java
@@ -136,4 +136,5 @@ public abstract class AbstractSlingStartMojo extends AbstractMojo {
     protected File getStandaloneOutputDirectory() {
         return new File(this.getTmpDir(), "standalone");
     }
+
 }

--- a/src/main/java/org/apache/sling/maven/slingstart/run/StartMojo.java
+++ b/src/main/java/org/apache/sling/maven/slingstart/run/StartMojo.java
@@ -50,6 +50,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.sling.maven.slingstart.BuildConstants;
+import org.apache.sling.maven.slingstart.PackageMojo;
 
 /**
  * Start one or multiple launchpad instance(s).
@@ -400,7 +401,14 @@ public class StartMojo extends AbstractStartStopMojo {
                 return attachedArtifact.getFile();
             }
         }
-
+        
+        // also check for jars in known target folders (in case the jar has been created in this project's target folder but not attached to the Maven project)
+        File localJarFile = PackageMojo.getNonPrimaryBuildFile(project, ".jar");
+        if (localJarFile.exists()) {
+            getLog().info("Using local launchpad jar being created in predefined directory: '" +  localJarFile + "'!");
+            return localJarFile;
+        }
+        
         // Last chance: use the first declared dependency with type "slingstart"
         final Set<Artifact> dependencies = this.project.getDependencyArtifacts();
         for (final Artifact dep : dependencies) {


### PR DESCRIPTION
introduce new parameter "attachArtifact" (default=true) to allow to
prevent attaching artifacts (only in case packaging != slingstart)